### PR TITLE
Add Dockerfile for easy deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Build this with: `docker build -t <image-name> .`
+# Run a container with: `docker run -it --rm --name <container-name>`
+FROM python:3-onbuild
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+	&& localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+ENV LANG de_DE.utf8
+
+# The following can be overwritten or parameters can be added:
+CMD [ "python", "session.py" ]


### PR DESCRIPTION
This adds a Dockerfile which can be used to build a Docker image in order to run the scraper inside a Docker container on any Linux system. This simplifies deployment and avoids dependency issues.

Build the container:

```
$> docker build -t scrape_da .
[...]
Successfully built <id>
```

Run the container on `$DOCKER_HOST`:

```
$> docker run -it --rm scrape_da
usage: RubinScraper [-h] -d DOMAIN -y
                    {2005,2006,2007,2008,2009,2010,2011,2012,2013,2014,2015}
RubinScraper: error: the following arguments are required: -d/--domain, -y/--year
```
